### PR TITLE
[CA-6683] Update link/composer.json file

### DIFF
--- a/docs/fresh.md
+++ b/docs/fresh.md
@@ -26,7 +26,7 @@ composer create-project roots/sage your-roots-theme-name-here
 cd your-roots-theme-name-here && composer require roots/acorn
 ```
 
-6. [Add "post-autoload-dump" script](https://github.com/wpengine/example-sage-theme/blob/main/post-deploy.sh) that'll run after every composer update command to the `composer.json`
+6. [Add "post-autoload-dump" script](https://github.com/wpengine/example-sage-theme/blob/main/wp-content/themes/your-roots-theme-name-here/composer.json#L63-L65) that'll run after every composer update command to the `composer.json`
 
 7. Create the directory structure for the github action
 ```bash

--- a/wp-content/themes/your-roots-theme-name-here/composer.json
+++ b/wp-content/themes/your-roots-theme-name-here/composer.json
@@ -39,7 +39,8 @@
     }
   },
   "require": {
-    "php": "^8.0"
+    "php": "^8.0",
+    "roots/acorn": "^3.2"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "3.7.1"
@@ -58,6 +59,9 @@
   "scripts": {
     "lint": [
       "phpcs --extensions=php --standard=PSR12 app"
+    ],
+    "post-autoload-dump": [
+      "Roots\\Acorn\\ComposerScripts::postAutoloadDump"
     ]
   },
   "extra": {


### PR DESCRIPTION
- Adds documentation links that show where to add the `composer.json` [from roots/acorn docs](https://roots.io/acorn/docs/installation/).
- Adds composer.json changes back that were removed during [security clean up](https://github.com/wpengine/example-sage-theme/commit/5dff83637ddf7eeb66fe603fb7dcc43ef16a54ce#diff-4c372f57ee258f33ebced6f4c9d4eece8fd08ac627ae9d0682080929d21d099eL43).

Side note: Turned off github's wiki, and build actions, since this is an example repo and we don't need those running on each PR. And merges to main shouldn't show a ❌  on the root of the project.