### PR TITLE
[CA-6683] bump php composer version to match compser.json

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -43,7 +43,7 @@ jobs:
 
   php-build:
     runs-on: ubuntu-latest
-    container: gjrdiesel/composer-74:alpine
+    container: gjrdiesel/composer-80:alpine
     steps:
 
     - name: Check out the git repo


### PR DESCRIPTION
Bumped roots/acorn for [security conerns](https://github.com/wpengine/example-sage-theme/commit/5dff83637ddf7eeb66fe603fb7dcc43ef16a54ce#diff-4c372f57ee258f33ebced6f4c9d4eece8fd08ac627ae9d0682080929d21d099eL42) and acorn dropped support for php7.4.

This PR bumps to latest php version w/ composer.